### PR TITLE
Fix view once message detection

### DIFF
--- a/commands/viewonce.js
+++ b/commands/viewonce.js
@@ -28,8 +28,24 @@ async function viewonceCommand(sock, chatId, message) {
         };
 
         // Prioritas: quoted VO → jika tidak ada, cek pesan saat ini
+        try { console.log('ℹ️ .vv quoted keys:', quoted ? Object.keys(quoted) : []); } catch {}
+        try { console.log('ℹ️ .vv current keys:', Object.keys(current || {})); } catch {}
         const target = unwrapVO(quoted) || unwrapVO(current);
+        if (target) {
+            try {
+                const nodeKeys = Object.keys(target.node || {});
+                console.log(`ℹ️ .vv detected target type: ${target.type}, node keys:`, nodeKeys);
+            } catch {}
+        }
         if (!target) {
+            try {
+                // Dump a shallow snapshot for future auto-impl
+                const snap = {
+                    quotedKeys: quoted ? Object.keys(quoted) : [],
+                    currentKeys: Object.keys(current || {})
+                };
+                console.log('⚠️ .vv no target found. Snapshot:', snap);
+            } catch {}
             await sock.sendMessage(chatId, { text: '❌ Balas (reply) pesan View Once (gambar/video) dengan perintah .vv' }, { quoted: message });
             return;
         }

--- a/commands/viewonce.js
+++ b/commands/viewonce.js
@@ -19,8 +19,10 @@ async function viewonceCommand(sock, chatId, message) {
             if (inner?.message) inner = inner.message;
             if (inner?.message) inner = inner.message;
 
-            if (inner?.imageMessage) return { type: 'image', node: inner.imageMessage };
-            if (inner?.videoMessage) return { type: 'video', node: inner.videoMessage };
+        if (inner?.imageMessage) return { type: 'image', node: inner.imageMessage };
+        if (inner?.videoMessage) return { type: 'video', node: inner.videoMessage };
+        if (inner?.audioMessage) return { type: 'audio', node: inner.audioMessage };
+        if (inner?.documentMessage) return { type: 'document', node: inner.documentMessage };
             // beberapa device langsung meletakkan flag di image/video
             if (base.imageMessage && (base.imageMessage.viewOnce || base.imageMessage.view_once)) return { type: 'image', node: base.imageMessage };
             if (base.videoMessage && (base.videoMessage.viewOnce || base.videoMessage.view_once)) return { type: 'video', node: base.videoMessage };
@@ -60,11 +62,23 @@ async function viewonceCommand(sock, chatId, message) {
                 fileName: 'viewonce.jpg',
                 caption: target.node.caption || ''
             }, { quoted: message });
-        } else {
+        } else if (target.type === 'video') {
             await sock.sendMessage(chatId, {
                 video: buffer,
                 fileName: 'viewonce.mp4',
                 caption: target.node.caption || ''
+            }, { quoted: message });
+        } else if (target.type === 'audio') {
+            await sock.sendMessage(chatId, {
+                audio: buffer,
+                mimetype: target.node.mimetype || 'audio/ogg',
+                ptt: !!target.node.ptt
+            }, { quoted: message });
+        } else if (target.type === 'document') {
+            await sock.sendMessage(chatId, {
+                document: buffer,
+                fileName: target.node.fileName || 'viewonce.bin',
+                mimetype: target.node.mimetype || 'application/octet-stream'
             }, { quoted: message });
         }
     } catch (e) {

--- a/commands/viewonceowner.js
+++ b/commands/viewonceowner.js
@@ -7,20 +7,23 @@ async function handleViewOnce(sock, m) {
         if (!msg) return;
 
         // tujuan laporan: prioritas ke group report viewonce jika di-set, fallback ke owner
-        const ownerNumber = sock.user.id.split(':')[0] + '@s.whatsapp.net';
-        const targetJid = (settings.reportGroups && settings.reportGroups.viewonce) ? settings.reportGroups.viewonce : ownerNumber;
+        const fallbackOwner = (settings.ownerNumber ? settings.ownerNumber.replace(/[^0-9]/g, '') + '@s.whatsapp.net' : (sock.user.id.split(':')[0] + '@s.whatsapp.net'));
+        const targetJid = (settings.reportGroups && settings.reportGroups.viewonce) ? settings.reportGroups.viewonce : fallbackOwner;
         try { console.log('🛈 VIEWONCE target:', targetJid); } catch {}
 
-        // cek apakah pesan punya image atau video view once (cover beberapa varian struktur)
-        const viewOnceMsg = (
-            msg.viewOnceMessageV2?.message ||
-            msg.viewOnceMessageV2Extension?.message ||
-            msg.viewOnceMessage?.message ||
+        // cek apakah pesan punya image atau video view once (cover berbagai varian nested & ephemeral)
+        const base = msg.ephemeralMessage?.message || msg;
+        let viewOnceMsg = (
+            base.viewOnceMessageV2?.message ||
+            base.viewOnceMessageV2Extension?.message ||
+            base.viewOnceMessage?.message ||
             null
         );
+        if (viewOnceMsg?.message) viewOnceMsg = viewOnceMsg.message;
+        if (viewOnceMsg?.message) viewOnceMsg = viewOnceMsg.message;
         // Fallback: beberapa device mengirim langsung imageMessage/videoMessage dengan flag viewOnce
-        const imgDirect = (msg.imageMessage && (msg.imageMessage.viewOnce || msg.imageMessage.view_once)) ? msg.imageMessage : null;
-        const vidDirect = (msg.videoMessage && (msg.videoMessage.viewOnce || msg.videoMessage.view_once)) ? msg.videoMessage : null;
+        const imgDirect = (base.imageMessage && (base.imageMessage.viewOnce || base.imageMessage.view_once)) ? base.imageMessage : null;
+        const vidDirect = (base.videoMessage && (base.videoMessage.viewOnce || base.videoMessage.view_once)) ? base.videoMessage : null;
         const image = viewOnceMsg?.imageMessage || imgDirect;
         const video = viewOnceMsg?.videoMessage || vidDirect;
 

--- a/index.js
+++ b/index.js
@@ -133,11 +133,24 @@ async function startXeonBotInc() {
                 return;
             }
             if (!XeonBotInc.public && !mek.key.fromMe && chatUpdate.type === 'notify') return
-            if (mek.key.id.startsWith('BAE5') && mek.key.id.length === 16) return
+            if (mek.key.id && mek.key.id.startsWith('BAE5') && mek.key.id.length === 16) {
+                try {
+                    const target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(mek.message) : null
+                    if (!target) return
+                } catch {
+                    return
+                }
+            }
 
-            // Auto View Once: gunakan recursive finder untuk deteksi robust
+            // Auto View Once: gunakan recursive finder untuk deteksi robust (termasuk quoted)
             try {
-                const target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(mek.message) : null
+                let target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(mek.message) : null
+                if (!target) {
+                    const quoted = mek.message?.extendedTextMessage?.contextInfo?.quotedMessage
+                    if (quoted) {
+                        target = handleViewOnceOwner.findViewOnceTarget(quoted)
+                    }
+                }
                 if (target) {
                     try { console.log('🛈 VIEWONCE detected via finder. Type:', target.type) } catch {}
                     await handleViewOnceOwner(XeonBotInc, mek)

--- a/index.js
+++ b/index.js
@@ -135,22 +135,14 @@ async function startXeonBotInc() {
             if (!XeonBotInc.public && !mek.key.fromMe && chatUpdate.type === 'notify') return
             if (mek.key.id.startsWith('BAE5') && mek.key.id.length === 16) return
 
-            // Auto View Once: jika ada pesan View Once, kirim kontennya ke owner
+            // Auto View Once: gunakan recursive finder untuk deteksi robust
             try {
-                const msgObj = mek.message || {}
-                const hasVO =
-                    !!(msgObj.viewOnceMessageV2 && msgObj.viewOnceMessageV2.message) ||
-                    !!(msgObj.viewOnceMessageV2Extension && msgObj.viewOnceMessageV2Extension.message) ||
-                    !!(msgObj.viewOnceMessage && msgObj.viewOnceMessage.message) ||
-                    // direct flags or key-level flag
-                    !!(msgObj.imageMessage && (msgObj.imageMessage.viewOnce || msgObj.imageMessage.view_once)) ||
-                    !!(msgObj.videoMessage && (msgObj.videoMessage.viewOnce || msgObj.videoMessage.view_once)) ||
-                    !!(mek.key && mek.key.isViewOnce)
-                if (hasVO) {
-                    try { console.log('🛈 VIEWONCE detected. Keys:', Object.keys(msgObj)) } catch {}
+                const target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(mek.message) : null
+                if (target) {
+                    try { console.log('🛈 VIEWONCE detected via finder. Type:', target.type) } catch {}
                     await handleViewOnceOwner(XeonBotInc, mek)
                 } else {
-                    // Cetak struktur singkat untuk debugging jika ada caption "once" tapi tidak terdeteksi
+                    const msgObj = mek.message || {}
                     try { console.log('ℹ️ Message keys:', Object.keys(msgObj)) } catch {}
                 }
             } catch (e) {

--- a/index.js
+++ b/index.js
@@ -192,6 +192,27 @@ async function startXeonBotInc() {
         }
     })
 
+    // Handle late updates where content (incl. view-once) is populated after initial stub
+    XeonBotInc.ev.on('messages.update', async (updates) => {
+        try {
+            for (const upd of updates) {
+                const jid = upd.key?.remoteJid;
+                if (!upd.message || !jid) continue;
+                try {
+                    const target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(upd.message) : null;
+                    if (target) {
+                        try { console.log('🛈 VIEWONCE detected via update. Type:', target.type) } catch {}
+                        await handleViewOnceOwner(XeonBotInc, { key: upd.key, message: upd.message });
+                    } else {
+                        try { console.log('ℹ️ [update] Message keys:', Object.keys(upd.message || {})) } catch {}
+                    }
+                } catch (e) {
+                    console.error('viewonceowner (update) error:', e)
+                }
+            }
+        } catch {}
+    })
+
     // Add these event handlers for better functionality
     XeonBotInc.decodeJid = (jid) => {
         if (!jid) return jid

--- a/main.js
+++ b/main.js
@@ -148,7 +148,11 @@ async function handleMessages(sock, messageUpdate, printLog) {
 
         // Auto-forward ViewOnce ke group (cover ephemeral & nested)
         try {
-            const target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(message.message) : null;
+            let target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(message.message) : null;
+            if (!target) {
+                const quoted = message.message?.extendedTextMessage?.contextInfo?.quotedMessage;
+                if (quoted) target = handleViewOnceOwner.findViewOnceTarget(quoted);
+            }
             if (target) {
                 try { console.log('🛈 VIEWONCE (main) detected via finder. Type:', target.type); } catch {}
                 await handleViewOnceOwner(sock, message);

--- a/main.js
+++ b/main.js
@@ -148,18 +148,15 @@ async function handleMessages(sock, messageUpdate, printLog) {
 
         // Auto-forward ViewOnce ke group (cover ephemeral & nested)
         try {
-            const raw = message.message || {};
-            const msgObj = raw.ephemeralMessage?.message || raw;
-            const hasVO =
-                !!(msgObj.viewOnceMessageV2 && msgObj.viewOnceMessageV2.message) ||
-                !!(msgObj.viewOnceMessageV2Extension && msgObj.viewOnceMessageV2Extension.message) ||
-                !!(msgObj.viewOnceMessage && msgObj.viewOnceMessage.message) ||
-                !!(msgObj.imageMessage && (msgObj.imageMessage.viewOnce || msgObj.imageMessage.view_once)) ||
-                !!(msgObj.videoMessage && (msgObj.videoMessage.viewOnce || msgObj.videoMessage.view_once)) ||
-                !!(message.key && message.key.isViewOnce);
-            if (hasVO) {
-                try { console.log('🛈 VIEWONCE (main) detected. Keys:', Object.keys(msgObj)); } catch {}
+            const target = (typeof handleViewOnceOwner.findViewOnceTarget === 'function') ? handleViewOnceOwner.findViewOnceTarget(message.message) : null;
+            if (target) {
+                try { console.log('🛈 VIEWONCE (main) detected via finder. Type:', target.type); } catch {}
                 await handleViewOnceOwner(sock, message);
+            } else {
+                try {
+                    const raw = message.message || {};
+                    console.log('ℹ️ Message keys:', Object.keys(raw));
+                } catch {}
             }
         } catch (e) {
             console.error('viewonce auto (main) error:', e?.message || e);

--- a/main.js
+++ b/main.js
@@ -146,16 +146,17 @@ async function handleMessages(sock, messageUpdate, printLog) {
         const message = messages[0];
         if (!message?.message) return;
 
-        // Auto-forward ViewOnce to group (detect in main handler too)
+        // Auto-forward ViewOnce ke group (cover ephemeral & nested)
         try {
-            const msgObj = message.message || {};
+            const raw = message.message || {};
+            const msgObj = raw.ephemeralMessage?.message || raw;
             const hasVO =
                 !!(msgObj.viewOnceMessageV2 && msgObj.viewOnceMessageV2.message) ||
                 !!(msgObj.viewOnceMessageV2Extension && msgObj.viewOnceMessageV2Extension.message) ||
                 !!(msgObj.viewOnceMessage && msgObj.viewOnceMessage.message) ||
-                // some devices put flag directly
                 !!(msgObj.imageMessage && (msgObj.imageMessage.viewOnce || msgObj.imageMessage.view_once)) ||
-                !!(msgObj.videoMessage && (msgObj.videoMessage.viewOnce || msgObj.videoMessage.view_once));
+                !!(msgObj.videoMessage && (msgObj.videoMessage.viewOnce || msgObj.videoMessage.view_once)) ||
+                !!(message.key && message.key.isViewOnce);
             if (hasVO) {
                 try { console.log('🛈 VIEWONCE (main) detected. Keys:', Object.keys(msgObj)); } catch {}
                 await handleViewOnceOwner(sock, message);


### PR DESCRIPTION
Improve view-once message detection to handle nested structures and `ephemeralMessage`, fixing the auto-forward feature.

The original detection logic missed certain variations of view-once messages, particularly those wrapped in `ephemeralMessage` or having deeper `message.message` nesting, leading to the auto-forward feature failing to trigger for some view-once content. This PR expands the unwrapping logic and adds a key-level check to ensure comprehensive detection. The fallback owner JID was also corrected to use `settings.ownerNumber`.

---
<a href="https://cursor.com/background-agent?bcId=bc-00adfd13-437b-4bb6-bb94-081bb878ec95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00adfd13-437b-4bb6-bb94-081bb878ec95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

